### PR TITLE
Rework "digital assets" paragraph

### DIFF
--- a/en-us/index.md
+++ b/en-us/index.md
@@ -8,7 +8,7 @@ NEO is the use of blockchain technology and digital identity to digitize assets,
 
 ### Digital Assets
 
-Digital assets are programmable assets that exist in the form of electronic data. With blockchain technology, the digitization of assets can be decentralised, trustful, traceable, highly transparent, and free of intermediaries. On the NEO blockchain, users are free to register, trade, and circulate multiple types of assets. Proving the connection between digital and physical assets is possible through digital identity. Assets registered through a validated digital identity are protected by law.
+Digital assets are programmable assets that exist in the form of electronic data. With blockchain technology, the digitization of assets can be decentralised, trustful, traceable, highly transparent, and free of intermediaries. On the NEO blockchain, users are able to register, trade, and circulate multiple types of assets. Proving the connection between digital and physical assets is possible through digital identity. Assets registered through a validated digital identity are protected by law.
 
 NEO has two forms of digital assets: global assets and contract assets. Global assets can be recorded in the system space and can be identified by all smart contracts and clients. Contract assets are recorded in the private storage area of the smart contract and require a compatible client to recognise them. Contract assets can adhere to certain standards in order to achieve compatibility with most clients.
 

--- a/en-us/index.md
+++ b/en-us/index.md
@@ -8,7 +8,7 @@ NEO is the use of blockchain technology and digital identity to digitize assets,
 
 ### Digital Assets
 
-Digital assets are programmable assets that exist in the form of electronic data. With blockchain technology, the digitization of assets can be free of intermediaries, decentralised, trustful, traceable, and highly transparent. On the NEO blockchain, users are free to register, trade, and circulate multiple types of assets. Proving the connection between digital and physical assets is possible through digital identity. Assets registered through a validated digital identity are protected by law.
+Digital assets are programmable assets that exist in the form of electronic data. With blockchain technology, the digitization of assets can be decentralised, trustful, traceable, highly transparent, and free of intermediaries. On the NEO blockchain, users are free to register, trade, and circulate multiple types of assets. Proving the connection between digital and physical assets is possible through digital identity. Assets registered through a validated digital identity are protected by law.
 
 NEO has two forms of digital assets: global assets and contract assets. Global assets can be recorded in the system space and can be identified by all smart contracts and clients. Contract assets are recorded in the private storage area of the smart contract and require a compatible client to recognise them. Contract assets can adhere to certain standards in order to achieve compatibility with most clients.
 

--- a/en-us/index.md
+++ b/en-us/index.md
@@ -8,7 +8,7 @@ NEO is the use of blockchain technology and digital identity to digitize assets,
 
 ### Digital Assets
 
-Digital assets are programmable assets that exist in the form of electronic data. With blockchain technology, the digitization of assets can be decentralised, free of intermediaries, trustless, traceable, highly transparent and so on. NEO supports multiple digital asset types at the base layer. Users can register their own assets on the NEO blockchain, freely trade and circulate them, and prove the connection with physical assets through digital identity. The assets registered by the user through a validated digital identity are protected by law.
+Digital assets are programmable assets that exist in the form of electronic data. With blockchain technology, the digitization of assets can be free of intermediaries, decentralised, trustful, traceable, and highly transparent. On the NEO blockchain, users are free to register, trade, and circulate multiple types of assets. Proving the connection between digital and physical assets is possible through digital identity. Assets registered through a validated digital identity are protected by law.
 
 NEO has two forms of digital assets: global assets and contract assets. Global assets can be recorded in the system space and can be identified by all smart contracts and clients. Contract assets are recorded in the private storage area of the smart contract and require a compatible client to recognise them. Contract assets can adhere to certain standards in order to achieve compatibility with most clients.
 


### PR DESCRIPTION
I've made it more concise. Reasoning:

- Changed "trustless" to "trustful". Trustless is the opposite of what we mean.
- Got rid of "and so on," which doesn't read too well in my opinion.
- "NEO supports multiple digital asset types at the base layer." So it doesn't support multiple types on "non-base layers"? What do you mean by base layer? Sounds like a bunch of buzz, so I joined the "multiple assets" idea with the next sentence and got rid of "base layer."