### PR TITLE
Update reference to Golang within Introduction

### DIFF
--- a/en-us/sc/introduction.md
+++ b/en-us/sc/introduction.md
@@ -23,7 +23,7 @@ The languages that are currently supported are:
 
 The languages that we plan to support include:
 
-1) C, C ++, GO
+1) C, C++, Golang
 2) Python, JavaScript
 
 With multiple-language support, more than 90% of developers can directly participate in the development of an NEO smart contract without the need to learn a new language. Existing business system code might even be directly ported to the blockchain. We envision that this will greatly increase the overall popularity of the future blockchain.


### PR DESCRIPTION
### Problem

Golang is currently being referred to as `GO` within the smart contract introduction document.

It should either be:

- Go 
- Golang

### Solution

Change to Golang.