### PR TITLE
Update to config.testnet.json

### DIFF
--- a/en-us/node/testnet.md
+++ b/en-us/node/testnet.md
@@ -31,8 +31,6 @@ Reference: [Introduction of NEO node](introduction.md).
 
 ![image](/assets/testnet_1.png)
 
-2. Copy the contents of the program (GUI) directory `neo-gui.exe.testnet.config` into the `neo-gui.exe.config` as shown in Figure
+2. Copy the contents of the program (GUI) directory `config.testnet.json` into the `config.json` as shown in Figure
 
-![image](/assets/testnet_2.png)
-
-Note: If the node is run on CLI, the contents of `config.testnet.json` need to be copied to` config.json`.
+![image](/assets/testnet_2_v2.png)


### PR DESCRIPTION
There isn't any **neo-gui.exe.testnet.config** file in the newest Neo GUI package (v.2.3.2).
Copying `config.testnet.json` into the `config.json` is the correct move.