### PR TITLE
fixed protocal/protocol typo

### DIFF
--- a/en-us/node/testnet.md
+++ b/en-us/node/testnet.md
@@ -27,7 +27,7 @@ Reference: [Introduction of NEO node](introduction.md).
 
 ## Method of switching to test network
 
-1. Copy the contents of the program directory under the `protocal.testnet.json` into ` protocol.json` as shown.
+1. Copy the contents of the program directory under the `protocol.testnet.json` into ` protocol.json` as shown.
 
 ![image](/assets/testnet_1.png)
 

--- a/ko-kr/node/testnet.md
+++ b/ko-kr/node/testnet.md
@@ -29,7 +29,7 @@ If you are a developer, you can ask for GAS on the TestNet here: https://www.neo
 
 ## 테스트 네트워크 변경 방법 (Method of switching to test network)
 
-1. 아래 나오는 것처럼 `protocal.testnet.json` 폴더 아래 있는 프로그램 폴더의 내용물들을 복사 해서 ` protocol.json`아래 붙여넣기 합니다. 
+1. 아래 나오는 것처럼 `protocol.testnet.json` 폴더 아래 있는 프로그램 폴더의 내용물들을 복사 해서 ` protocol.json`아래 붙여넣기 합니다. 
 
 ![image](https://github.com/neo-project/docs/blob/master/assets/testnet_1.png)
 

--- a/zh-cn/node/testnet.md
+++ b/zh-cn/node/testnet.md
@@ -25,7 +25,7 @@ NEO 的测试网（Test Net）是官方提供的，专供用户来开发、调�
 
 ## 切换测试网的方法
 
-1、将程序目录下的 `protocal.testnet.json` 里的内容复制到 `protocol.json`（替换原有配置文件），如图。
+1、将程序目录下的 `protocol.testnet.json` 里的内容复制到 `protocol.json`（替换原有配置文件），如图。
 
 ![](/assets/testnet_1_v2.png)
 


### PR DESCRIPTION
Fixed typo in protocol.testnet.json filename in testnet instructions for Chinese, English and Korean versions