### PR TITLE
Clarified system fees for Storage.Put

### DIFF
--- a/en-us/sc/systemfees.md
+++ b/en-us/sc/systemfees.md
@@ -34,9 +34,11 @@ All Smart Contract fees are considered as Service fee to be put in a pool for re
 | Contract.Create                       | 500           |
 | Contract.Migrate                      | 500           |
 | Storage.Get                           | 0.1           |
-| Storage.Put [per KB]                  | 1             |
+| Storage.Put [per KB]*                 | 1             |
 | Storage.Delete                        | 0.1           |
 | (Default)                             | 0.001         |
+
+* Additional to 1 GAS minimum
 
 ### Fees for Instructions
 


### PR DESCRIPTION
I felt like this system fee needed more clarity as the per KB cost is in addition to a 1 GAS fee. This makes the mechanics different to the other [per item] calls which do not charge a minimum fee in addition to their item cost.

I couldn't think of a super elegant way to convey the min fee so a footnote seemed appropriate.

Issue raised here: https://github.com/neo-project/neo/issues/124