### PR TITLE
Fix GetValue/GetScriptHash mixup

### DIFF
--- a/de-de/sc/api/neo.md
+++ b/de-de/sc/api/neo.md
@@ -50,8 +50,8 @@ Transaction Class API:
 | Neo.Input.GetHash             | Den Hash der referenzierten vorherigen Transaktion abfragen |
 | Neo.Input.GetIndex            | Der Index des Inputs in der Output-Liste der referenzierten vorherigen Transaktion |
 | Neo.Output.GetAssetId         | Asset ID abfragen |
-| Neo.Output.GetValue           | Script Hash abfragen |
-| Neo.Output.GetScriptHash      | Transaktionsbetrag abfragen |
+| Neo.Output.GetValue           | Transaktionsbetrag abfragen |
+| Neo.Output.GetScriptHash      | Script Hash abfragen |
 
 Account Class API:
 

--- a/en-us/sc/api/neo.md
+++ b/en-us/sc/api/neo.md
@@ -51,8 +51,8 @@ Transaction class API:
 | Neo.Input.GetHash             | Get the hash of the referenced previous transaction |
 | Neo.Input.GetIndex            | The index of the input in the output list of the referenced previous transaction |
 | Neo.Output.GetAssetId         | Get Asset ID                             |
-| Neo.Output.GetValue           | Get Script Hash                          |
-| Neo.Output.GetScriptHash      | Get the transaction amount               |
+| Neo.Output.GetValue           | Get the transaction amount               |
+| Neo.Output.GetScriptHash      | Get Script Hash                          |
 
 Account class API:
 

--- a/es-es/sc/api/Neo.md
+++ b/es-es/sc/api/Neo.md
@@ -54,8 +54,8 @@ API de la clase **Transaction:**
 | Neo.Input.GetHash | La transación que hace referencia en la transación. |
 | Neo.Input.GetIndex | Índice de la transacción referenciada en su lista de transacciones de salida. |
 | Neo.Output.GetAssetId | Obtiene el ID del activo. |
-| Neo.Output.GetValue | Obtiene el hash del script. |
-| Neo.Output.GetScriptHash | Obtiene el total de la transacción. |
+| Neo.Output.GetValue | Obtiene el total de la transacción. |
+| Neo.Output.GetScriptHash | Obtiene el hash del script. |
 
 API de la clase **Account:**
 

--- a/it-it/sc/api/neo.md
+++ b/it-it/sc/api/neo.md
@@ -50,8 +50,8 @@ Transaction Class API:
 | Neo.Input.GetHash             | Ottiene l'hash della transazione precedente riferita |
 | Neo.Input.GetIndex            | L'indice dell'input nell'elenco output della transazione precedente riferita |
 | Neo.Output.GetAssetId         | Ottiene l'ID dell'asset |
-| Neo.Output.GetValue           | Ottiene l'hash dello script |
-| Neo.Output.GetScriptHash      | Ottiene l'importo della transazione |
+| Neo.Output.GetValue           | Ottiene l'importo della transazione |
+| Neo.Output.GetScriptHash      | Ottiene l'hash dello script |
 
 Account class API:
 

--- a/ja-jp/sc/api/neo.md
+++ b/ja-jp/sc/api/neo.md
@@ -50,8 +50,8 @@ Transaction クラスAPI：
 | Neo.Input.GetHash             | 参照されている前のトランザクションのハッシュを取得する |
 | Neo.Input.GetIndex            | 参照されている前のトランザクションの出力リスト内の入力のインデックス |
 | Neo.Output.GetAssetId         | アセットIDを取得する |
-| Neo.Output.GetValue           | スクリプトハッシュを取得する |
-| Neo.Output.GetScriptHash      | トランザクションの量を取得する |
+| Neo.Output.GetValue           | トランザクションの量を取得する |
+| Neo.Output.GetScriptHash      | スクリプトハッシュを取得する |
 
 Account クラスAPI：
 

--- a/nl-nl/sc/api/neo.md
+++ b/nl-nl/sc/api/neo.md
@@ -51,8 +51,8 @@ Transaction class API:
 | Neo.Input.GetHash             | Krijg de hash van een gerefereerde vorige transactie 
 | Neo.Input.GetIndex            | Krijg de index van de input in de output-lijst van de gerefereerde vorige transactie 
 | Neo.Output.GetAssetId         | Krijg het Asset ID 
-| Neo.Output.GetValue           | Krijg de Script Hash 
-| Neo.Output.GetScriptHash      | Krijg de transactie-hoeveelheid
+| Neo.Output.GetValue           | Krijg de transactie-hoeveelheid
+| Neo.Output.GetScriptHash      | Krijg de Script Hash 
 
 Account class API:
 

--- a/zh-cn/sc/api/neo.md
+++ b/zh-cn/sc/api/neo.md
@@ -48,8 +48,8 @@ NEO 命名空间是 NEO 区块链所提供的 API，提供了访问区块链账�
 | Neo.Input.GetHash             | 所引用的交易的交易散列                              |
 | Neo.Input.GetIndex            | 所引用的交易输出在其全部交易输出列表中的索引                   |
 | Neo.Output.GetAssetId         | 获得资产 ID                                  |
-| Neo.Output.GetValue           | 获得脚本散列                                   |
-| Neo.Output.GetScriptHash      | 获得交易金额                                   |
+| Neo.Output.GetValue           | 获得交易金额                                   |
+| Neo.Output.GetScriptHash      | 获得脚本散列                                   |
 | Neo.Enrollment.GetPublicKey   | ` 已弃用 ` 已用 Neo.Blockchain.GetValidators 替代 |
 
 账户类 API：


### PR DESCRIPTION
The documentation mixed up `Neo.Output.GetScriptHash` and `Neo.Output.GetValue`, this mistake was translated in all other languages.

This PR fixes it by simply exchanging the documentation of those two calls.