### PR TITLE
Feature/java tutorial linux instructions

### DIFF
--- a/en-us/sc/getting-started-java.md
+++ b/en-us/sc/getting-started-java.md
@@ -70,8 +70,15 @@ Download the [neo-compiler](https://github.com/neo-project/neo-compiler) project
 ```
 cd neo-compiler/neoj
 dotnet build
-dotnet run
 ```
+
+NOTE: At this point, after having launched the build command, you could get the following error:
+`It was not possible to find any compatible framework version
+ The specified framework 'Microsoft.NETCore.App', version '1.0.4' was not found.`
+ 
+If this is the case, open neoj.csproj and change the RuntimeFrameworkVersion's tag with your dotnet version. 
+For example `<RuntimeFrameworkVersion>2.0.5</RuntimeFrameworkVersion>`
+
 
 We now need to add this directory to our execution path. The PATH is the system variable that your operating system uses to locate needed executables from the command line or Terminal window.
 
@@ -139,11 +146,16 @@ Build the project which will give you `HelloWorld.class` in your out folder.
 Then using neoj, run cmd.exe and execute:
 > neoj.exe HelloWorld.class
 
-**Linux**
+**Linux:**
 
-From the same folder call
+Copy the jar in the dotnet's folder. For example:
+
+`sudo cp org.neo.smartcontract.framework.jar /usr/share/dotnet`
+
+and then call
 
 > dotnet run HelloWorld.class
+
 
 If successful, it will create HelloWorld.avm which you can now use as smart contract bytecode.
 

--- a/en-us/sc/getting-started-java.md
+++ b/en-us/sc/getting-started-java.md
@@ -28,11 +28,12 @@ The most efficient way of getting these steps done is to download and compile al
 1. Download Neo's Node GUI. At the time of writing, it is recommended you use the BETA developer GUI as it has some extra debugging features which are helpful. [CoZ NEO GUI](https://github.com/CityOfZion/neo-gui-developer). It will have default presets to Testnet and you will have to wait (up to a few hours) for it to fully sync up.
 2. Download the Neo Framework Library JAR. The current latest version is here: [org.neo.smartcontract.framework JAR](https://github.com/CityOfZion/neo-java-sdk/blob/master/target/org.neo.smartcontract.framework.jar)
 3. Download an IDE for Java (optional but recommended), e.g. IntelliJ or Eclipse.
-4. Download an IDE for C# - currently the neoj compiler needs to be built manually as it is not in wide distribution release format. Recommended is to get Visual Studio 2017 which is free.
+4. (Windows only) Download an IDE for C# - currently the neoj compiler needs to be built manually as it is not in wide distribution release format. Recommended is to get Visual Studio 2017 which is free.
 
 ## Development Tools
 
-### 1. Visual Studio 2017
+
+#### 1. Visual Studio 2017 (Windows)
 
 If you have already installed Visual Studio 2017 on your computer and checked for .NET Cross-Platform Development at the time of installation, you can skip this section.
 
@@ -48,6 +49,7 @@ The installation process is very simple, follow the operation prompts step-by-st
 
 Installation and configuration steps:
 
+**Windows:** 
 Download the [neo-compiler](https://github.com/neo-project/neo-compiler) project on Github, open the solution with Visual Studio 2017, and publish the neoj project.
 
 Publish the neoj compiler (which converts Java bytecode to the AVM bytecode).
@@ -57,6 +59,19 @@ Publish the neoj compiler (which converts Java bytecode to the AVM bytecode).
 ![publish and profile settings](/assets/publish_and_profile_settings.png)
 
 After the release is successful, the neoj.exe file is generated in `bin\Release\PublishOutput`.
+
+**Linux:**
+
+Since there's no "publish" function in Visual Studio Code for Linux we build it manually.
+Make sure you have [dotnet](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#install-net-core-for-ubuntu-1404-ubuntu-1604-ubuntu-1610--linux-mint-17-linux-mint-18-64-bit) installed.
+
+Download the [neo-compiler](https://github.com/neo-project/neo-compiler) project on Github.
+
+```
+cd neo-compiler/neoj
+dotnet build
+dotnet run
+```
 
 We now need to add this directory to our execution path. The PATH is the system variable that your operating system uses to locate needed executables from the command line or Terminal window.
 
@@ -84,6 +99,14 @@ Now run Command or PowerShell, and enter neoj.exe. If there is no error and the 
 
 NOTE. Windows 7 SP1 users might encounter an error "Unhandled Exception: System.DllNotFoundException: Unable to load DLL 'api-ms-win-core-console-l2-1-0.dll': The specified module could not be found". The required 'api-ms-win-core-console-l2-1-0.dll' file is only found in Windows 8 or later versions. This error can be resolved by obtaining a copy of 'api-ms-win-core-console-l2-1-0.dll' and putting it in the directory C:\Windows\System32. This dll can potentially be found in a number of places throughout one's system(search your computer and copy/past it into \System32), but alternatively can be found online.
 
+**Linux**
+
+Add this to your ~/.profile or ~/.bashrc file:
+
+`export PATH=$PATH:/path/to/neo-compiler`
+
+then execute `source ~/.profile` or `source ~/.bashrc`
+
 ## Create project
 
 After the above installation is complete you can create a Java project (e.g. using Eclipse or IntelliJ).
@@ -109,7 +132,9 @@ public class HelloWorld extends SmartContract {
 }
 ```
 
-Build the project which will give you `HelloWorld.class` in your out folder.
+Build the project with either your IDE or from command line, which will give you `HelloWorld.class`
+
+`javac HelloWorld.java -cp org.neo.smartcontract.framework.jar`
 
 Then using neoj, run cmd.exe and execute:
 > neoj.exe HelloWorld.class

--- a/en-us/sc/getting-started-java.md
+++ b/en-us/sc/getting-started-java.md
@@ -132,12 +132,18 @@ public class HelloWorld extends SmartContract {
 }
 ```
 
-Build the project with either your IDE or from command line, which will give you `HelloWorld.class`
+Build the project which will give you `HelloWorld.class` in your out folder.
 
-`javac HelloWorld.java -cp org.neo.smartcontract.framework.jar`
+**Windows:**
 
 Then using neoj, run cmd.exe and execute:
 > neoj.exe HelloWorld.class
+
+**Linux**
+
+From the same folder call
+
+> dotnet run HelloWorld.class
 
 If successful, it will create HelloWorld.avm which you can now use as smart contract bytecode.
 

--- a/it-it/sc/getting-started-java.md
+++ b/it-it/sc/getting-started-java.md
@@ -28,11 +28,11 @@ Il modo più efficiente di portare a termine questi passaggi è di scaricare e d
 1. Scaricare la GUI Node di NEO. Al momento della scrittura, è raccomandato usare la GUI di sviluppo BETA siccome ha delle funzionalità extra utili per il debugging. [CoZ NEO GUI](https://github.com/CityOfZion/neo-gui-developer). Sarà configurata di default sulla Testnet e dovrai aspettare (fino a poche ore) la sincronizzazione completa.
 2. Scaricare il Framework Library JAR di NEO. L'ultima versione corrente si trova qui: [Antshares.SmartContract.Framework JAR](https://github.com/CityOfZion/neo-java-sdk/blob/master/target/org.neo.smartcontract.framework.jar)
 3. Scaricare una IDE per Java (opzionale ma raccomandato), come IntelliJ o Eclipse.
-4. Scaricare una IDE per C# - attualmente il compilatore neoj deve essere costruito manualmente siccome non è nel formato di rilascio a larga scala. È raccomandato avere il software gratuito Visual Studio 2017.
+4. (Solo per Windows) Scaricare una IDE per C# - attualmente il compilatore neoj deve essere costruito manualmente siccome non è nel formato di rilascio a larga scala. È raccomandato avere il software gratuito Visual Studio 2017.
 
 ## Strumenti di Sviluppo
 
-### 1. Visual Studio 2017
+### 1. Visual Studio 2017 (Windows)
 
 Se hai già installato Visual Studio 2017 sul tuo computer e spuntato la casella .NET Cross-Platform Development al momento dell'installazione, puoi saltare questa sezione.
 
@@ -48,6 +48,8 @@ Il processo di installazione è davvero semplice, basta seguire le istruzioni su
 
 Passaggi di installazione e configurazione:
 
+**Windows:**
+
 Scaricare il progetto [neo-compiler](https://github.com/neo-project/neo-compiler) su Github, aprire la soluzione con Visual Studio 2017 e pubblicare il progetto neoj.
 
 Pubblicare il compilatore neoj (che converte Java bytecode in AVM bytecode).
@@ -57,6 +59,20 @@ Pubblicare il compilatore neoj (che converte Java bytecode in AVM bytecode).
 ![publish and profile settings](/assets/publish_and_profile_settings.png)
 
 Una volta rilasciato con successo, il file neoj.exe viene generato in `bin\Release\PublishOutput`.
+
+**Linux:**
+
+Siccome non c'è la funzione "publish" in Visual Studio Code per Linux, dobbiamo fare la build manualmente.
+
+Assicurati di avere [dotnet](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#install-net-core-for-ubuntu-1404-ubuntu-1604-ubuntu-1610--linux-mint-17-linux-mint-18-64-bit) installato.
+
+Scarica il progetto [neo-compiler](https://github.com/neo-project/neo-compiler) da GitHub.
+
+```
+cd neo-compiler/neoj
+dotnet build
+dotnet run
+```
 
 Adesso occorre aggiungere questa directory al nostro percorso di esecuzione. La PATH è la variabile di sistema che il tuo sistema operativo usa per localizzare eseguibili richiesti dalla linea di comando o dalla finestra del Terminal.
 
@@ -82,6 +98,15 @@ Adesso eseguire il Command o PowerShell, e inserire neoj.exe. Se non vi sono err
 ![powershell enviornment variabled updated correctly](/assets/powershell_enviornment_variabled_updated_correctly.png)
 
 NOTA: Gli utenti di Windows 7 SP1 potrebbero incorrere all'errore "Unhandled Exception: System.DllNotFoundException: Unable to load DLL 'api-ms-win-core-console-l2-1-0.dll': The specified module could not be found". Il file richiesto 'api-ms-win-core-console-l2-1-0.dll' é solo disponibile in Windows 8 o versioni successive. Questo errore può essere risolto ottenendo una copia di 'api-ms-win-core-console-l2-1-0.dll' e spostandola nella directory C:\Windows\System32.
+
+**Linux**
+
+Aggiungi la seguente stringa nel tuo file ~/.profile o ~/.bashrc:
+
+`export PATH=$PATH:/path/to/neo-compiler`
+
+poi esegui `source ~/.profile` o `source ~/.bashrc`, a dipendenza di quale file hai modificato.
+
 
 ## Creare un Progetto
 
@@ -110,9 +135,17 @@ public class HelloWorld extends SmartContract{
 
 Costruire il progetto che restituirá `HelloWorld.class` nella tua cartella d'uscita.
 
+**Windows**
+
 Poi usando neoj, avvia cmd.exe ed esegui:
 
 > neoj.exe HelloWorld.class
+
+**Linux**
+
+Sempre dalla cartella chiama
+
+> dotnet run HelloWorld.class
 
 Se il comando è eseguito con successo, creerà HelloWorld.avm che può essere usato come smart contract bytecode.
 

--- a/it-it/sc/getting-started-java.md
+++ b/it-it/sc/getting-started-java.md
@@ -71,8 +71,13 @@ Scarica il progetto [neo-compiler](https://github.com/neo-project/neo-compiler) 
 ```
 cd neo-compiler/neoj
 dotnet build
-dotnet run
 ```
+
+NOTA: A questo punto, dopo aver lanciato la build, potreste riscontrare il seguente errore:
+`It was not possible to find any compatible framework version
+ The specified framework 'Microsoft.NETCore.App', version '1.0.4' was not found.`
+ 
+ Se questo é il caso, apri il file neoj.csproj e modifica il contenuto del tag RuntimeFrameworkVersion con la tua versione di dotnet. Per esempio `<RuntimeFrameworkVersion>2.0.5</RuntimeFrameworkVersion>`
 
 Adesso occorre aggiungere questa directory al nostro percorso di esecuzione. La PATH è la variabile di sistema che il tuo sistema operativo usa per localizzare eseguibili richiesti dalla linea di comando o dalla finestra del Terminal.
 
@@ -143,7 +148,11 @@ Poi usando neoj, avvia cmd.exe ed esegui:
 
 **Linux**
 
-Sempre dalla cartella chiama
+Copia il jar nella cartella di dotnet per poter compilare con successo. Per esempio con:
+
+`sudo cp org.neo.smartcontract.framework.jar /usr/share/dotnet`
+
+poi esegui
 
 > dotnet run HelloWorld.class
 


### PR DESCRIPTION
This adds more information on how to compile and run the Java tutorial in a Linux (Ubuntu) environment in response to #386.
Also mentions a couple of issues which can occur while following the steps.

How does it work with the additional translations?