### PR TITLE
Fix command to generate new dotnet library

### DIFF
--- a/en-us/sc/quickstart/getting-started-csharp-ubuntu.md
+++ b/en-us/sc/quickstart/getting-started-csharp-ubuntu.md
@@ -13,7 +13,7 @@ To develop smart contracts in C# on ubuntu, basically you need to do the followi
    ```c#
    mkdir NeoContractDemo
    cd ./NeoContractDemo/
-   dotnet new library
+   dotnet new classlib
    rm ./Class1.cs
    vim NeoContractDemo.cs
    ```


### PR DESCRIPTION
`dotnet new library` generates an error with dotnet version 2.1.402