### PR TITLE
Update neo-cli OSX installation instructions

### DIFF
--- a/en-us/node/cli/publish.md
+++ b/en-us/node/cli/publish.md
@@ -57,19 +57,19 @@ dotnet publish -c release -r win10-x64
 
 ### Installing required files
 
-1. Git clone NEO-CLI source code from [Github](https://github.com/neo-project/neo-cli.git) or using the following command:
+1. Git clone [NEO-CLI](https://github.com/neo-project/neo-cli.git) and [NEO-CORE](https://github.com/neo-project/neo.git) source code from Github or using the following commands:
 
    ```
    $ git clone https://github.com/neo-project/neo-cli.git
+   $ git clone https://github.com/neo-project/neo.git
+   ```
+2. Download the LevelDB to RocksDB patch file into the core project folder.
+   
+   ```
+   $ wget --directory-prefix=neo https://gist.githubusercontent.com/ixje/359fbffa62eddbbf2b9ca716bf958487/raw/f402fb76edb2767c22e5d65847347bf8dae6d7bd/0001-convert-leveldb-to-rocksdb.patch
    ```
 
-2. Git clone the altered neo dependency using rocksdb.
-
-   ```
-   $ git clone -b rocksdb-proxy https://github.com/ixje/neo.git
-   ```
-
-3. Install rocksdb using Homebrew.
+3. Install RocksDB using Homebrew.
 
    ```
    $ brew install rocksdb
@@ -77,14 +77,26 @@ dotnet publish -c release -r win10-x64
 
 4. Install [Visual Studio for Mac](https://www.visualstudio.com/vs/mac/).
 
-### Managing to compile
+### Setting up project code
+The NEO project is under constant development. As a result we have to make sure we checkout compatible `NEO-CLI` and `NEO-CORE` versions.
 
-1. Open the folder `neo-cli` and launch `neo-cli.sln` in Visual Studio
-2. Right click on neo-cli's solution folder `neo-cli (master)` and `Add` > `Add Existing Project...`
-3. Navigate to the `neo` folder to find and choose `neo.csproj` inside another `neo` folder
-4. Right click on neo-cli's project Dependencies folder and choose `Edit References...`
+1. Open a terminal and navigate to the `neo-cli` project folder
+2. Use `git tag` to view a list of available versions and checkout the version you like e.g. `git checkout tags/v2.9.4`
+3. Navigate to the `neo` core project folder (where the patch file is located) and repeat step 2. Make sure you checkout compatible versions!
+4. Apply the patch that changes the LevelDB wrapper to use RocksDB
+
+   ```
+   $ git apply 0001-convert-leveldb-to-rocksdb.patch
+   ```
+
+### Setting up Visual Studio
+
+1. Open the `neo-cli` folder and launch `neo-cli.sln` in Visual Studio
+2. Right click on neo-cli's solution folder `neo-cli` and `Add` > `Add Existing Project...`
+3. Navigate to the `neo` folder and choose `neo.csproj` (located inside the sub folder `neo`)
+4. Right click on neo-cli's project `Dependencies` folder and choose `Edit References...`
 5. Click the checkmark on `neo` and press `ok`
-6. Click the `Project` menu bar to `Restore NuGet Packages` and `Update NuGet Packages`
+6. Click the `Project` menu bar and choose `Restore NuGet Packages`, once done choose `Update NuGet Packages`
 7. Click the `Build` menu bar to `Rebuild All` just in case of errors
 
 ### Building the executable file


### PR DESCRIPTION
The current installation instructions for OSX are outdate/incomplete. Part of the instructions point to a special branch on my repository that was once created for a really old neo-cli build (2.8.0 or 2.7.6). 

I have now created a special patch file (instead of a separate branch) which can be applied to any new version of neo/neo-cli. This makes sure users can always use the latest `neo-cli` while developing on OSX. I've updated the instructions to make sure users can get started quickly and do not fall into common traps (like having compatible neo-cli and neo-core versions).