### PR TITLE
Define link explicitly

### DIFF
--- a/en-us/basic/about.md
+++ b/en-us/basic/about.md
@@ -63,7 +63,7 @@
 
 - **-dBFT:** Original consensus mechanism created by NEO Blockchain
 
-  <https://steemit.com/neo/@basiccrypto/neo-s-consensus-protocol-how-delegated-byzantine-fault-tolerance-works>
+  [https://steemit.com/neo/@basiccrypto/neo-s-consensus-protocol-how-delegated-byzantine-fault-tolerance-works](https://steemit.com/neo/@basiccrypto/neo-s-consensus-protocol-how-delegated-byzantine-fault-tolerance-works)
 
   <https://docs.neo.org/en-us/08_dbft.pdf>
 


### PR DESCRIPTION
Because of the existence of `@` in the link, it is getting interpreted as a mail addresses and added a `mailto:`, this PR defines the link explicitly so it's interpreted correctly.