### PR TITLE
fix offline package links

### DIFF
--- a/en-us/network/syncblocks.md
+++ b/en-us/network/syncblocks.md
@@ -14,7 +14,7 @@ The client must be fully synchronized before use. In order to speed up network s
 
 ## Step 1 - Download the offline package
 
-1. Close the NEO client and go to [offline synchronized package](http://sync.ngd.network/) downloading page.
+1. Close the NEO client and go to [offline synchronized package](https://sync.ngd.network/) downloading page.
 
 2. From the offline package downloading page, click **Mainnet** or **Testnet** according to your network and then download one of the following packages (no need to unzip the package):
 

--- a/ru-ru/network/syncblocks.md
+++ b/ru-ru/network/syncblocks.md
@@ -11,7 +11,7 @@
 
 ## Шаг 1 – Загрузите офф-лайн пакет
 
-1. Закройте клиент NEO и щелкните кнопкой мыши по [Download offline synchronized package](http://sync.ngd.network/)  со страницы [Client Downloads](https://neo.org/download).
+1. Закройте клиент NEO и щелкните кнопкой мыши по [Download offline synchronized package](https://sync.ngd.network/)  со страницы [Client Downloads](https://neo.org/download).
 
    ![](../../assets/syncblocks_1.png)
 


### PR DESCRIPTION
the links to `sync.ngd.network` _must_ be HTTPS or they will not work.