### PR TITLE
Remove Nest Fund explanation

### DIFF
--- a/docs/en-us/basic/technology/neocontract.md
+++ b/docs/en-us/basic/technology/neocontract.md
@@ -235,12 +235,6 @@ Superconducting transactions is a mechanism that can do this; Users do not need 
 
 At present, within the NEO community, development of smart contracts to achieve blockchain superconducting transactions has emerged, such as OTCGO.
 
-### Smart Fund
-
-Smart funds based on the blockchain have the benefit of being decentralized, open and transparent, possessing a higher degree of security and freedom as compared to traditional funds. These smart funds are also cross-border and open to investors worldwide, where outstanding projects can be funded with capital from all across the world.
-
-Nest is a NeoContract-based smart fund project, which is very similar to the TheDAO project based on Ethereum, where improved security measures is needed to avoid the mistakes of TheDAO (hackers).
-
 ### Cross-chain Interoperability
 
 In the foreseeable future, there will be many public chains and thousands of alliance chains or private chains in existence worldwide. These isolated blockchain systems are islands of value and information, which are not interoperable with each other. Through the cross-chain interoperability mechanism, numerous isolated blockchains can be linked, so that the values in different blockchains can be exchanged with each other, to achieve the true value of the Internet.


### PR DESCRIPTION
Remove content about the Nest fund because it's not relevant anymore.