### PR TITLE
NEO-191 Fix NEP17 errors in the docs

### DIFF
--- a/docs/en-us/develop/write/nep17.md
+++ b/docs/en-us/develop/write/nep17.md
@@ -6,79 +6,127 @@ NEP17 assets are recorded in the contract storage area, through updating account
 
 In the method definitions below, we provide both the definitions of the functions as they are defined in the contract as well as the invoke parameters.
 
-**totalSupply**    
+**totalSupply**
 
-```c#
-public static BigInteger totalSupply()
-```
+    {
+      "name": "totalSupply",
+      "parameters": [],
+      "returntype": "Integer"
+    }
 
 Returns the total token supply deployed in the system.
 
 **symbol**
 
-```c#
-public static string symbol()
-```
+    {
+      "name": "symbol",
+      "parameters": [],
+      "returntype": "String"
+    }
 
 Returns a short string symbol of the token managed in this contract. e.g. "MYT". 
 
-This symbol must be a valid ASCII string, with no whitespace characters or new-lines, and should be short (3-8 characters is recommended) uppercase latin alphabet (i.e. the 26 letters used in English).
+ This string MUST be valid ASCII, MUST NOT contain whitespace or control characters, SHOULD be limited to uppercase Latin alphabet (i.e. the 26 letters used in English) and SHOULD be short (3-8 characters is recommended). 
 
 This method MUST always return the same value every time it is invoked.
 
 **decimals**
 
-```c#
-public static byte decimals()
-```
+    {
+      "name": "decimals",
+      "parameters": [],
+      "returntype": "Integer"
+    }
 
-Returns the number of decimals used by the token - e.g. 8, means to divide the token amount by 100,000,000 to get its user representation.
+Returns the number of decimals used by the token - e.g. `8`, means to divide the token amount by `100,000,000` to get its user representation.
 
 This method MUST always return the same value every time it is invoked.
 
 **balanceOf**
 
-```c#
-public static BigInteger balanceOf(byte[] account)
-```
+    {
+      "name": "balanceOf",
+      "parameters": [
+        {
+          "name": "account",
+          "type": "Hash160"
+        }
+      ],
+      "returntype": "Integer"
+    }
 
 Returns the token balance of the `account`.
 
-The parameter `account` must be a 20-byte address. If not, this method should throw an exception.
+The parameter `account` MUST be a 20-byte address. If not, this method SHOULD `throw` an exception.
 
-If the `account` is an unused address, this method must return 0.
+If the `account` is an unused address, this method MUST return `0`.
 
 **transfer**
 
-```c#
-public static bool transfer(byte[] from, byte[] to, BigInteger amount)
-```
+    {
+      "name": "transfer",
+      "parameters": [
+        {
+          "name": "from",
+          "type": "Hash160"
+        },
+        {
+          "name": "to",
+          "type": "Hash160"
+        },
+        {
+          "name": "amount",
+          "type": "Integer"
+        },
+        {
+          "name": "data",
+          "type": "Any"
+        }
+      ],
+      "returntype": "Boolean"
+    }
 
-The parameters `from` and `to` should be 20-byte addresses. If not, this method should throw an exception.<br/>
+Transfers an `amount` of tokens from the `from` account to the `to` account. 
 
-The parameter amount must be greater than or equal to 0. If not, this method should throw an exception.<br/>
+The parameters `from` and `to` MUST be 20-byte addresses. If not, this method SHOULD `throw` an exception.<br/>
 
-The function must return false if the `from` account balance does not have enough tokens to spend.<br/>
+The parameter `amount` MUST be greater than or equal to `0`. If not, this method SHOULD `throw` an exception.<br/>
 
-If the method succeeds, it must fire the `Transfer` event, and must return `true`, even if the `amount` is 0, or `from` and `to` are the same address.<br/>
+The function MUST return `false` if the `from` account balance does not have enough tokens to spend.<br/>
+
+If the method succeeds, it MUST fire the `Transfer` event, and MUST return `true`, even if the `amount` is `0`, or `from` and `to` are the same address.<br/>
 
 The function SHOULD check whether the `from` address equals the caller contract hash. If so, the transfer SHOULD be processed; If not, the function SHOULD use the SYSCALL `Neo.Runtime.CheckWitness` to verify the transfer.<br/>
 
-If the transfer is not processed successfully, the function must return `false`.
+If the transfer is not processed, the function MUST return `false`.
 
-If `to` is the address hash of a deployed contract, the function must invoke the `onPayment` method of the contract after triggering the `Transfer` event. If the contract `to` does not want to receive the transfer, it must invoke the opcode `ABORT`.
+If the receiver is a deployed contract, the function MUST call `onPayment` method on receiver contract with the `data` parameter from `transfer` AFTER firing the `Transfer` event. If the receiver doesn't want to receive this transfer it MUST call `ABORT`. 
 
 **Transfer Event**
 
-```c#
-public static event transfer(byte[] from, byte[] to, BigInteger amount)
-```
+    {
+      "name": "Transfer",
+      "parameters": [
+        {
+          "name": "from",
+          "type": "Hash160"
+        },
+        {
+          "name": "to",
+          "type": "Hash160"
+        },
+        {
+          "name": "amount",
+          "type": "Integer"
+        }
+      ]
+    }
 
-This event MUST be triggered when tokens are transferred, including the case where `amount` is 0 and `from` and `to` are the same address.<br/>
+MUST trigger when tokens are transferred, including zero value transfers and self-transfers. <br/>
 
-A token contract which creates new tokens MUST trigger a `Transfer` event with the `from` address set to null when tokens are created.<br/>
+A token contract which creates new tokens MUST trigger a `Transfer` event with the `from` address set to `null` when tokens are created.<br/>
 
-A token contract which burns tokens MUST trigger a `Transfer` event with the `to` address set to null when tokens are burned.
+A token contract which burns tokens MUST trigger a `Transfer` event with the `to` address set to `null` when tokens are burned.
 
 NEP17 methods are as follows. For the complete code refer to [NEP-17 contract code](https://github.com/neo-project/examples/tree/37487a324b4be695af422f37d668e15a05d75e1e/csharp/NEP17).
 


### PR DESCRIPTION
The current doc has outdated function signatures and some of the texts did not correspond 100% with the ones at [NEP17](https://github.com/neo-project/proposals/pull/126/files?short_path=e39836e#diff-e39836e1dc236bd36413c0a15a41ea9f968729d1eb888b7f0d36d98bd1d2d357).