### PR TITLE
Update an example in the document

### DIFF
--- a/docs/en-us/develop/write/basics.md
+++ b/docs/en-us/develop/write/basics.md
@@ -21,7 +21,7 @@ namespace Helloworld
         private const string test_str = "Hello World";
         public static string Hello()
         {
-            Storage.Put("Hello", "World");
+            Storage.Put(Storage.CurrentContext, "Hello", "World");
             return test_str;
         }
     }


### PR DESCRIPTION
In NEO 3, no overload for method 'Put' of Storage takes 2 arguments. This PR is to fix this compilation error in the example.