### PR TITLE
Fix missing documentation about max key length for Storage.

### DIFF
--- a/docs/en-us/reference/scapi/framework/services/Storage/Delete.md
+++ b/docs/en-us/reference/scapi/framework/services/Storage/Delete.md
@@ -17,7 +17,7 @@ Parameters:
 
 - Context: Storage context as a [StorageContext](../StorageContext.md).
 
-- Key: Key as a byte array or string.
+- Key: Key as a byte array or string. Max length 64 bytes.
 
 
 Return value: void.

--- a/docs/en-us/reference/scapi/framework/services/Storage/Get.md
+++ b/docs/en-us/reference/scapi/framework/services/Storage/Get.md
@@ -17,7 +17,7 @@ Parameters:
 
 Context: Storage context as a [StorageContext](../StorageContext.md).
 
-Key: Key as a byte array or string.
+Key: Key as a byte array or string. Max length 64 bytes.
 
 Return Value: The value corresponding to the key as a byte array.
 

--- a/docs/en-us/reference/scapi/framework/services/Storage/Put.md
+++ b/docs/en-us/reference/scapi/framework/services/Storage/Put.md
@@ -23,7 +23,7 @@ Put(StorageContext context, ByteString key, ByteString value, StorageFlags flags
 Parameters:
 
 - context: Storage context as a [StorageContext](../StorageContext.md).
-- key: Key as a byte array or string.
+- key: Key as a byte array or string. Max length 64 bytes.
 - value: Value as a byte array, Biginteger, or string.
 - flag: StorageFlags type, representing a variable or constant in storage.
 

--- a/docs/zh-cn/reference/scapi/framework/services/Storage/Delete.md
+++ b/docs/zh-cn/reference/scapi/framework/services/Storage/Delete.md
@@ -15,7 +15,7 @@ public static extern void Delete(StorageContext context, ByteString key);
 参数：
 
 - context：存储上下文，[StorageContext](../StorageContext.md) 类型;
-- key：键，字节数组或者字符串。
+- key：键，字节数组或者字符串。最大长度64字节。
 
 返回值：void。
 

--- a/docs/zh-cn/reference/scapi/framework/services/Storage/Get.md
+++ b/docs/zh-cn/reference/scapi/framework/services/Storage/Get.md
@@ -16,7 +16,7 @@ public static extern byte[] Get(StorageContext context, ByteString key);
 参数：
 
 - context：存储上下文，[StorageContext](../StorageContext.md) 类型;
-- key：键，字节数组或者字符串。
+- key：键，字节数组或者字符串。最大长度64字节。
 
 返回值：key 对应的 value，字节数组。
 

--- a/docs/zh-cn/reference/scapi/framework/services/Storage/Put.md
+++ b/docs/zh-cn/reference/scapi/framework/services/Storage/Put.md
@@ -23,7 +23,7 @@ Put(StorageContext context, ByteString key, ByteString value, StorageFlags flags
 参数：
 
 - context：存储上下文，[StorageContext](../StorageContext.md) 类型；
-- key：键，字节数组/字符串；
+- key：键，字节数组/字符串；最大长度64字节。
 - value：值，字节数组/大整数/字符串。
 - flags：StorageFlags 类型，标识存储的是变量还是常量
 


### PR DESCRIPTION
Hi, looks like you are missing the documentations about max key length for Storage service.

According to https://github.com/neo-project/neo-vm/blob/master/src/neo-vm/Types/Map.cs#L18 , here is a limitation of 64 bytes for key used in map. For `Storage.Put(ctx, key, value)`, this behavior is also confirmed, but it's not documented. 

This pr fixed the doc by mentioning that in `Storage.Put`, `Storage.Get` and `Storage.Delete`, both in English and Chinese.
