### PR TITLE
Found content missing in English from Chinese

### DIFF
--- a/docs/en-us/develop/network/private-chain/solo.md
+++ b/docs/en-us/develop/network/private-chain/solo.md
@@ -64,7 +64,7 @@ Here is an example：
 
 In the config.json under the `Plugins\DBFTPlugin` directory make the following change:
 
-- Set `AutoStart` as true
+- Set `AutoStart` as true, and set `Network` same as the `Network` in config.json under the Neo-cli directory.
 
 Here is an example:
 


### PR DESCRIPTION
原中文：
设置 AutoStart 为 true，并将 Network 与 neo-cli 的 config.json 中的 Network 设为相同数值，例如：

原英文：
Set AutoStart as true

（不但属于翻译不符，还涉及到了步骤缺漏的问题。应补充完整。）