### PR TITLE
Update nep5.md

### DIFF
--- a/docs/en-us/sc/write/nep5.md
+++ b/docs/en-us/sc/write/nep5.md
@@ -15,6 +15,7 @@ public static BigInteger totalSupply()
 Returns the total token supply deployed in the system.
 
 **name**    
+
 ```c#
 public static string name()
 ```


### PR DESCRIPTION
Add whitespace between `name` and its signature to make the code block be properly rendered, as the other methods.