### PR TITLE
update to .NET 6.0 & Visual Studio 2022 for contract developers

### DIFF
--- a/docs/en-us/develop/write/difference.md
+++ b/docs/en-us/develop/write/difference.md
@@ -6,7 +6,7 @@ This document describes the main differences in writing smart contracts between 
 
 ### .NET Core
 
-In Neo N3, .NET Core version has been upgraded from 3.0 to 5.0. You need to update SDK.
+In Neo N3, .NET Core version has been upgraded from 3.0 to 6.0. You need to update SDK.
 
 ### Visual Studio Extension
 

--- a/docs/en-us/gettingstarted/develop.md
+++ b/docs/en-us/gettingstarted/develop.md
@@ -8,7 +8,7 @@ The following steps are applicable to multiple system platforms, such as Windows
 
 1. Download and install [Visual Studio Code](https://code.visualstudio.com/Download)
 
-2. Download and install [.NET 5.0 SDK](https://dotnet.microsoft.com/download)
+2. Download and install [.NET 6.0 SDK](https://dotnet.microsoft.com/download)
 
 3. Run the command line and enter the following command to check if you have installed SDK successfully. 
 

--- a/docs/en-us/node/cli/setup.md
+++ b/docs/en-us/node/cli/setup.md
@@ -72,7 +72,7 @@ You can download and compile the Neo-CLI source directly from Github.
 
 ### Publishing using Visual Studio (Windows)
 
-If you has Visual Studio 2019 installed on your Windows system, this way is recommended:
+If you has Visual Studio 2022 installed on your Windows system, this way is recommended:
 
 1. In Visual Studio, open the project file neo-node.sln.
 2. In the Solution panel, right click `neo-cli` and select `Publish`.

--- a/docs/zh-cn/develop/write/difference.md
+++ b/docs/zh-cn/develop/write/difference.md
@@ -6,7 +6,7 @@
 
 ### .NET Core
 
-在 Neo N3 中，.NET Core 版本从 3.0 升级为 5.0，需要更新 SDK。
+在 Neo N3 中，.NET Core 版本从 3.0 升级为 6.0，需要更新 SDK。
 
 ### Visual Studio 扩展
 

--- a/docs/zh-cn/gettingstarted/develop.md
+++ b/docs/zh-cn/gettingstarted/develop.md
@@ -8,7 +8,7 @@
 
 1. 下载并安装 [Visual Studio Code](https://code.visualstudio.com/Download)
 
-2. 下载并安装 [.NET 5.0 SDK](https://dotnet.microsoft.com/download)
+2. 下载并安装 [.NET 6.0 SDK](https://dotnet.microsoft.com/download)
 
 3. 打开系统命令行，执行命令查看是否成功安装 SDK。
 

--- a/docs/zh-cn/node/cli/setup.md
+++ b/docs/zh-cn/node/cli/setup.md
@@ -71,7 +71,7 @@
 
 ### 使用Visual Studio发布（仅Windows）
 
-如果使用 Windows 系统且已安装 Visual Studio 2019, 推荐此方法进行发布：
+如果使用 Windows 系统且已安装 Visual Studio 2022, 推荐此方法进行发布：
 
 1. 在 Visual Studio 中打开项目文件 neo-node.sln, 在解决方案栏中右键单击 `neo-cli`，点击`发布`。
 

--- a/tutorials/en-us/development.md
+++ b/tutorials/en-us/development.md
@@ -133,7 +133,7 @@ Run the following command to build your contract：
 dotnet build
 ```
 
-Related contract files are outputted under `\bin\Debug\net5.0` path in the contract project directory.
+Related contract files are outputted under `\bin\Debug\net6.0` path in the contract project directory.
 
 ## Deploying the contract
 


### PR DESCRIPTION
(.NET 5.0 is kept in the docs for exchanges and committee nodes)